### PR TITLE
Fix displayname limitation with twitter

### DIFF
--- a/src/components/auth/RegistrationFormStepper.vue
+++ b/src/components/auth/RegistrationFormStepper.vue
@@ -20,9 +20,9 @@
         type="text"
         hint="後から変更できます"
         counter
-        maxlength="15"
+        maxlength="50"
         lazy-rules
-        :rules="[ val =>(0 < (val).length && (val).length < (16) ) || '1文字以上、15文字以内']"
+        :rules="[ val =>(0 < (val).length && (val).length < (51) ) || '1文字以上、50文字以内']"
         @keyup.enter="displayName.length > 0 ? $refs.stepper.next() : null"
       >
       </q-input>

--- a/src/pages/edit/EditProfile.vue
+++ b/src/pages/edit/EditProfile.vue
@@ -22,7 +22,7 @@
             :placeholder="displayName || $store.state.auth.user.displayname"
             counter
             hint="1文字以上"
-            maxlength="30"
+            maxlength="50"
             lazy-rules
             :rules="[
               val => val !== null && val !== '' || 'Please enter name',
@@ -57,7 +57,7 @@ export default {
       displayName: '',
       description: this.$store.state.auth.user.description,
       patternUsername: /^[a-z0-9_]{1,15}$/i,
-      patternDisplayname: /^.{1,30}$/i,
+      patternDisplayname: /^.{1,50}$/i,
       loadingBtn: false
     }
   },


### PR DESCRIPTION
Fix #38 

ツイッター登録時に自動で読み込むTwitterの表示名に対応するため
表示名の文字数上限を15文字から50文字に緩和した。